### PR TITLE
fix(ImageGenerator): show core-shape outline on coremap editor

### DIFF
--- a/src/EditView.js
+++ b/src/EditView.js
@@ -481,6 +481,7 @@ export default class EditView extends React.Component {
           cells={this.state.cells}
           assemblyLayouts={this.state.rodmaps}
           assemblies={this.state.assemblies}
+          coremaps={this.state.coremaps}
           imageSize={this.props.imageSize}
         />
       );

--- a/src/utils/InpHelper.js
+++ b/src/utils/InpHelper.js
@@ -152,6 +152,24 @@ function stripCoreZeros(textMap, coreMap) {
   });
   return lines.join('\n');
 }
+
+function getCoreShape(coremaps, inShapeMap = null) {
+  let coreShapeMap = inShapeMap;
+  // set title, build a core_shape array.
+  // Set locations occupied in any map to 1, empty to 0
+  coremaps.forEach((cm, j) => {
+    if (!coreShapeMap) {
+      coreShapeMap = cm.cell_map.map((cell) => (cell !== '-' ? 1 : 0));
+    } else {
+      cm.cell_map.forEach((cell, i) => {
+        if (cell !== '-') coreShapeMap[i] = 1;
+        else if (j === 0) coreShapeMap[i] = 0;
+      });
+    }
+  });
+  return coreShapeMap;
+}
+
 // inverse of 'parseFile' - take a state, and write as much as
 // we can to .inp format, as a string.
 function writeToInp(state, GROUP_TYPES) {
@@ -166,15 +184,11 @@ function writeToInp(state, GROUP_TYPES) {
   result.push(`  apitch ${state.params.assemblyPitch}`);
 
   const groupTitles = {};
-  let coreShapeMap = null;
+  const coreShapeMap = getCoreShape(state.coremaps);
   // set title, build a core_shape array.
   // Set locations occupied in any map to 1, empty to 0
   state.coremaps.forEach((cm) => {
     groupTitles[cm.group] = cm.label;
-    if (!coreShapeMap) coreShapeMap = cm.cell_map.map((c) => 0);
-    cm.cell_map.forEach((cell, i) => {
-      if (cell !== '-') coreShapeMap[i] = 1;
-    });
   });
   if (coreShapeMap) {
     const coreShape = {
@@ -294,6 +308,7 @@ function writeToInp(state, GROUP_TYPES) {
 }
 
 export default {
+  getCoreShape,
   getNumPins,
   getTextMap,
   getFullMap,

--- a/src/widgets/AssemblyLayoutEditor.js
+++ b/src/widgets/AssemblyLayoutEditor.js
@@ -200,6 +200,13 @@ export default class AssemblyLayoutEditor extends React.Component {
       if (!this.props.content.cellMap) {
         this.props.content.cellMap = this.getTextMap();
       }
+      if (this.props.content.type === 'coremaps') {
+        // update the coreShape
+        this.props.content.coreShape = InpHelper.getCoreShape(
+          this.props.coremaps,
+          this.props.content.coreShape
+        );
+      }
       updateLayoutImage(
         this.props.content,
         cellNameToIdMap,
@@ -350,6 +357,7 @@ AssemblyLayoutEditor.propTypes = {
   type: PropTypes.string,
   cells: PropTypes.array,
   assemblies: PropTypes.array,
+  coremaps: PropTypes.array,
   imageSize: PropTypes.number,
 };
 
@@ -359,5 +367,6 @@ AssemblyLayoutEditor.defaultProps = {
   // materials: [],
   cells: [],
   assemblies: [],
+  coremaps: [],
   imageSize: 512,
 };


### PR DESCRIPTION
Generate a coremap whenever the layout changes, and show an outline
with the maximum extent. Larger rows towards the outside affect
inner rows.