### PR TITLE
 feat(CoreEditor): add core full-stack view

### DIFF
--- a/src/EditView.js
+++ b/src/EditView.js
@@ -558,7 +558,7 @@ export default class EditView extends React.Component {
                 }
               >
                 {this.state.coremaps.length && (
-                  <Menu.Item key="core:stack">
+                  <Menu.Item key="core">
                     <span className={style.itemWithSmallIcon}>
                       <Icon type="check-square-o" />Full stack
                     </span>

--- a/src/EditView.js
+++ b/src/EditView.js
@@ -14,6 +14,7 @@ import ParamEditor from './widgets/ParamEditor';
 import CellEditor from './widgets/CellEditor';
 import AssemblyEditor from './widgets/AssemblyEditor';
 import AssemblyLayoutEditor from './widgets/AssemblyLayoutEditor';
+import CoreEditor from './widgets/CoreEditor';
 // import VTKRenderer from './widgets/VTKRenderer';
 import ModelHelper from './utils/ModelHelper';
 import InpHelper from './utils/InpHelper';
@@ -37,6 +38,7 @@ const EDITORS = {
   Assemblies: AssemblyEditor,
   Rodmaps: AssemblyLayoutEditor,
   Coremaps: AssemblyLayoutEditor,
+  Core: CoreEditor,
   Params: ParamEditor,
 };
 
@@ -167,6 +169,7 @@ export default class EditView extends React.Component {
       rodmaps: [],
       assemblies: [],
       coremaps: [],
+      core: { stack: {} },
       params: {
         numPins: 1,
         pinPitch: 1.26,
@@ -443,7 +446,7 @@ export default class EditView extends React.Component {
               group: info.group,
             };
             InpHelper.setSymmetry(newMap, params);
-            console.log(newMap);
+            // console.log(newMap);
             coremaps.push(newMap);
           }
         });
@@ -453,7 +456,7 @@ export default class EditView extends React.Component {
           coremaps,
         });
       }
-      console.log('editor', newState);
+      // console.log('editor', newState);
     });
     return false;
   }
@@ -482,6 +485,7 @@ export default class EditView extends React.Component {
           assemblyLayouts={this.state.rodmaps}
           assemblies={this.state.assemblies}
           coremaps={this.state.coremaps}
+          core={this.state.core}
           imageSize={this.props.imageSize}
         />
       );
@@ -553,6 +557,13 @@ export default class EditView extends React.Component {
                   </span>
                 }
               >
+                {this.state.coremaps.length && (
+                  <Menu.Item key="core:stack">
+                    <span className={style.itemWithSmallIcon}>
+                      <Icon type="check-square-o" />Full stack
+                    </span>
+                  </Menu.Item>
+                )}
                 {GROUP_TYPES.map((info) => {
                   const anyAsm = this.state.assemblies.filter(
                     (asm) => asm.group === info.group

--- a/src/MainView.js
+++ b/src/MainView.js
@@ -233,22 +233,6 @@ export default class MainView extends React.Component {
       );
     }
 
-    if (this.state.content && !(this.state.use3D && this.state.has3D)) {
-      contents.push(
-        <div
-          key="2d-content"
-          className={this.state.legend ? style.mainImageFull : style.mainImage}
-        >
-          <ReactCursorPosition>
-            <ImageRenderer
-              content={this.state.content}
-              getImageInfo={this.getImageInfo}
-            />
-          </ReactCursorPosition>
-        </div>
-      );
-    }
-
     if (
       this.state.legend &&
       this.state.content &&
@@ -265,6 +249,22 @@ export default class MainView extends React.Component {
               border
             />
           ))}
+        </div>
+      );
+    }
+
+    if (this.state.content && !(this.state.use3D && this.state.has3D)) {
+      contents.push(
+        <div
+          key="2d-content"
+          className={this.state.legend ? style.mainImageFull : style.mainImage}
+        >
+          <ReactCursorPosition>
+            <ImageRenderer
+              content={this.state.content}
+              getImageInfo={this.getImageInfo}
+            />
+          </ReactCursorPosition>
         </div>
       );
     }

--- a/src/utils/ImageGenerator.js
+++ b/src/utils/ImageGenerator.js
@@ -451,14 +451,13 @@ function updateItemWithLayoutImages(
 
     // Update map
     if (!LAYOUT_MAP[category][item.label]) {
-      LAYOUT_MAP[category][item.label] = {
-        __axial_labels: item.axial_labels,
-        __axial_elevations: item.axial_elevations,
-        __3d_layouts: item.stack.has3D.layouts,
-      };
+      LAYOUT_MAP[category][item.label] = {};
     }
-    LAYOUT_MAP[category][item.label][item.layout[count].label] =
-      item.layout[count];
+    const map = LAYOUT_MAP[category][item.label];
+    map.__axial_labels = item.axial_labels;
+    map.__axial_elevations = item.axial_elevations;
+    map.__3d_layouts = item.stack.has3D.layouts;
+    map[item.layout[count].label] = item.layout[count];
   }
 
   // Create 3D stack assembly
@@ -942,36 +941,66 @@ function computeCore2ImageAt(elevation, core, size = 1500, edge = 250) {
 
 // ----------------------------------------------------------------------------
 
-function compute3DCore(core, resolution = 6, baffleOffset = 0) {
-  const coreSize = core.core_size;
-  const coreShape = core.shape;
-  const gridSpacing = core.apitch;
+function compute3DCore(
+  content,
+  core,
+  resolution = 6,
+  baffleOffset = 0,
+  params = null,
+  mapList = null
+) {
+  // maps coming from the editor are completely filled out with '-',
+  // so no coreShape array to provide bounds.
+  const coreSize = core ? core.core_size : params.numAssemblies;
+  const coreShape = core ? core.shape : null;
+  const gridSpacing = core ? core.apitch : params.assemblyPitch;
 
   // Local variables for mapping
-  const assemMap = core.assm_map;
-  const ctrlMap = core.crd_map;
-  const detMap = core.det_map;
-  const insMap = core.insert_map;
+  const assemMap = core
+    ? core.assm_map
+    : mapList.reduce(
+        (prev, m) => (m.group === 'assemblies' ? m.cell_map : prev),
+        null
+      );
+  const ctrlMap = core
+    ? core.crd_map
+    : mapList.reduce(
+        (prev, m) => (m.group === 'controls' ? m.cell_map : prev),
+        null
+      );
+  const detMap = core
+    ? core.det_map
+    : mapList.reduce(
+        (prev, m) => (m.group === 'detectors' ? m.cell_map : prev),
+        null
+      );
+  const insMap = core
+    ? core.insert_map
+    : mapList.reduce(
+        (prev, m) => (m.group === 'inserts' ? m.cell_map : prev),
+        null
+      );
+
   // labels specific control rods (crd)
-  const bankMap = core.crd_bank;
+  const bankMap = core ? core.crd_bank : null;
+
+  const coreHeight = core ? core.height : 300;
 
   const layouts = [];
   const grids = [];
   let gridArraySize = 0;
-  const content = {
-    labelToUse: 'Full core',
-    has3D: {
-      id: idFor3D++,
-      type: 'core',
-      lookupTable: materialLookupTable,
-      layouts: [],
-      center: [
-        coreSize * gridSpacing * 0.5,
-        coreSize * gridSpacing * 0.5,
-        core.height * 0.5,
-      ],
-      height: core.height,
-    },
+  content.labelToUse = 'Full core';
+  content.has3D = {
+    id: idFor3D++,
+    type: 'core',
+    lookupTable: materialLookupTable,
+    layouts: [],
+    center: [
+      coreSize * gridSpacing * 0.5,
+      coreSize * gridSpacing * 0.5,
+      coreHeight * 0.5,
+    ],
+    height: coreHeight,
   };
 
   const processingList = [
@@ -984,7 +1013,7 @@ function compute3DCore(core, resolution = 6, baffleOffset = 0) {
   let pidx = 0;
   for (let j = 0; j < coreSize; j++) {
     for (let i = 0; i < coreSize; i++) {
-      if (coreShape[i + j * coreSize]) {
+      if (!coreShape || coreShape[i + j * coreSize]) {
         const offsetX = i * gridSpacing;
         const offsetY = j * gridSpacing;
         for (let k = 0; k < processingList.length; k++) {
@@ -1124,6 +1153,8 @@ function compute3DCore(core, resolution = 6, baffleOffset = 0) {
     colorData: gridColorData,
     lookupTable: materialLookupTable,
   };
+
+  if (!core) return content;
 
   // Add vessel
   const vesselGlyph = ModelHelper.extractVesselAsCellFromCore(core);

--- a/src/utils/ImageGenerator.js
+++ b/src/utils/ImageGenerator.js
@@ -679,7 +679,7 @@ function computeCore2ImageAt(elevation, core, size = 1500, edge = 250) {
   const coreSize = core.core_size;
   const recWidth = Math.floor((size - 2 * edge) / coreSize);
   const radius = recWidth / 6;
-  const coreShape = core.shape;
+  const coreShape = core.shape; // might be null
   const offset = (size - recWidth * coreSize) / 2;
   const colorLegend = {};
   const localColorManager = colorManagerByElevation[elevation];
@@ -762,7 +762,7 @@ function computeCore2ImageAt(elevation, core, size = 1500, edge = 250) {
   let pidx = 0;
   for (let j = 0; j < coreSize; j++) {
     for (let i = 0; i < coreSize; i++) {
-      if (coreShape[i + j * coreSize]) {
+      if (!coreShape || coreShape[i + j * coreSize]) {
         // if the coremap has an assembly at this location, tag comes before the ':'
         // if the assembly has a cellmap at this elevation, tag comes after ':'
         const assemKey = getElevationKey(
@@ -951,40 +951,20 @@ function compute3DCore(
 ) {
   // maps coming from the editor are completely filled out with '-',
   // so no coreShape array to provide bounds.
-  const coreSize = core ? core.core_size : params.numAssemblies;
-  const coreShape = core ? core.shape : null;
-  const gridSpacing = core ? core.apitch : params.assemblyPitch;
+  const coreSize = core.core_size;
+  const coreShape = core.shape;
+  const gridSpacing = core.apitch;
 
   // Local variables for mapping
-  const assemMap = core
-    ? core.assm_map
-    : mapList.reduce(
-        (prev, m) => (m.group === 'assemblies' ? m.cell_map : prev),
-        null
-      );
-  const ctrlMap = core
-    ? core.crd_map
-    : mapList.reduce(
-        (prev, m) => (m.group === 'controls' ? m.cell_map : prev),
-        null
-      );
-  const detMap = core
-    ? core.det_map
-    : mapList.reduce(
-        (prev, m) => (m.group === 'detectors' ? m.cell_map : prev),
-        null
-      );
-  const insMap = core
-    ? core.insert_map
-    : mapList.reduce(
-        (prev, m) => (m.group === 'inserts' ? m.cell_map : prev),
-        null
-      );
+  const assemMap = core.assm_map;
+  const ctrlMap = core.crd_map;
+  const detMap = core.det_map;
+  const insMap = core.insert_map;
 
   // labels specific control rods (crd)
-  const bankMap = core ? core.crd_bank : null;
+  const bankMap = core.crd_bank;
 
-  const coreHeight = core ? core.height : 300;
+  const coreHeight = core.height;
 
   const layouts = [];
   const grids = [];
@@ -1154,7 +1134,7 @@ function compute3DCore(
     lookupTable: materialLookupTable,
   };
 
-  if (!core) return content;
+  if (!core.shape) return content;
 
   // Add vessel
   const vesselGlyph = ModelHelper.extractVesselAsCellFromCore(core);

--- a/src/utils/ModelHelper.js
+++ b/src/utils/ModelHelper.js
@@ -425,7 +425,7 @@ function parseFile(file, imageSize, updateFn) {
   updateFn({ title: file.name, file });
   XMLVeraParser.parseFile(file).then(
     (dataModel) => {
-      const core = {};
+      const core = { stack: {} };
       const elevations = extractElevations(dataModel);
       const cells = extractCells(dataModel);
       const mask = {};
@@ -495,7 +495,8 @@ function parseFile(file, imageSize, updateFn) {
         ImageGenerator.updateLookupTables();
 
         // Fill core
-        core.stack = ImageGenerator.compute3DCore(
+        ImageGenerator.compute3DCore(
+          core.stack,
           dataModel.CASEID.CORE,
           6,
           lastPPitch / 2

--- a/src/utils/ModelHelper.js
+++ b/src/utils/ModelHelper.js
@@ -287,6 +287,18 @@ function extractElevations(model) {
   return elevations.filter((v, i, a) => a[i - 1] !== v);
 }
 
+function extractCoremapElevations(mapList) {
+  let elevations = [];
+  let count = mapList.length;
+  while (count--) {
+    elevations = elevations.concat(mapList[count].axial_elevations);
+  }
+
+  elevations.sort(compareNumbers);
+
+  return elevations.filter((v, i, a) => a[i - 1] !== v);
+}
+
 function extractStates(model) {
   const rootKey = 'STATES';
   const result = [];
@@ -421,6 +433,29 @@ function extractBaffleLayoutFrom(core, baffleOffset) {
   return baffle;
 }
 
+function extractCoreElevations(core, elevations, dataModel) {
+  let count = elevations.length - 1;
+  while (count--) {
+    const elevation = elevations[count];
+    // pre-assign non-conflicting colors.
+    ImageGenerator.computeCoreColorsAt(elevation, dataModel);
+  }
+  count = elevations.length - 1;
+  while (count--) {
+    const elevation = elevations[count];
+    core[elevation] = {
+      imageSrc: ImageGenerator.computeCore2ImageAt(elevation, dataModel),
+      legend: ImageGenerator.getColorLegendAt(elevation),
+      has3D: ImageGenerator.compute3DSlice(
+        core.stack.has3D,
+        elevation,
+        elevations[count + 1]
+      ),
+      labelToUse: `${elevation} to ${elevations[count + 1]}`,
+    };
+  }
+}
+
 function parseFile(file, imageSize, updateFn) {
   updateFn({ title: file.name, file });
   XMLVeraParser.parseFile(file).then(
@@ -503,6 +538,7 @@ function parseFile(file, imageSize, updateFn) {
         );
         core.assemblyPitch = dataModel.CASEID.CORE.apitch;
         core.numAssemblies = dataModel.CASEID.CORE.core_size;
+        core.name = dataModel.CASEID.CORE.name;
         // extract info about control-rod motion
         if (controls && controls[0] && controls[0].stroke && core.stack.has3D) {
           // stroke card is specified once for [CONTROL] block - extract the first.
@@ -522,29 +558,7 @@ function parseFile(file, imageSize, updateFn) {
           if (map) core[mapName] = [].concat(map);
         });
 
-        count = elevations.length - 1;
-        while (count--) {
-          const elevation = elevations[count];
-          // pre-assign non-conflicting colors.
-          ImageGenerator.computeCoreColorsAt(elevation, dataModel.CASEID.CORE);
-        }
-        count = elevations.length - 1;
-        while (count--) {
-          const elevation = elevations[count];
-          core[elevation] = {
-            imageSrc: ImageGenerator.computeCore2ImageAt(
-              elevation,
-              dataModel.CASEID.CORE
-            ),
-            legend: ImageGenerator.getColorLegendAt(elevation),
-            has3D: ImageGenerator.compute3DSlice(
-              core.stack.has3D,
-              elevation,
-              elevations[count + 1]
-            ),
-            labelToUse: `${elevation} to ${elevations[count + 1]}`,
-          };
-        }
+        extractCoreElevations(core, elevations, dataModel.CASEID.CORE);
 
         updateFn({
           assemblies,
@@ -570,6 +584,7 @@ function parseFile(file, imageSize, updateFn) {
 }
 
 export default {
+  extractCoreElevations,
   extractVesselAsCellFromCore,
   extractPadAsCellsFromCore,
   extractPlateAsCellsFromCore,
@@ -580,6 +595,7 @@ export default {
   extractDetectors,
   extractInserts,
   extractElevations,
+  extractCoremapElevations,
   extractBaffleLayoutFrom,
   parseFile,
 };

--- a/src/widgets/CoreEditor.js
+++ b/src/widgets/CoreEditor.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// import ReactCursorPosition from 'react-cursor-position';
+
+import { Form, Input } from 'antd';
+
+// import macro from 'vtk.js/Sources/macro';
+import DualRenderer from './DualRenderer';
+import ImageGenerator from '../utils/ImageGenerator';
+
+import style from '../assets/vera.mcss';
+
+const FormItem = Form.Item;
+
+// const TYPES = ['fuel', 'other'];
+const { compute3DCore, updateLookupTables } = ImageGenerator;
+
+export default class CoreEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      use3D: true,
+      rendering: {},
+    };
+
+    this.onFieldUpdate = this.onFieldUpdate.bind(this);
+    this.update3D = this.update3D.bind(this);
+  }
+
+  componentDidMount() {
+    this.update3D();
+    // update image
+    this.props.update();
+  }
+
+  onFieldUpdate(e) {
+    const value = e.target.value;
+    const id = e.target.dataset.id;
+    this.props.content[id] = value;
+    if (id === 'label' && this.props.content.id !== 'new-000') {
+      this.props.content.labelToUse = value;
+    }
+    this.props.update();
+    this.update3D();
+  }
+
+  update3D() {
+    updateLookupTables();
+    compute3DCore(
+      this.props.content,
+      null,
+      6,
+      this.props.params.pinPitch * 0.5,
+      this.props.params,
+      this.props.coremaps
+    );
+    // this.props.content.has3D.source.forceUpdate = true;
+    this.setState({
+      rendering: this.props.content.has3D,
+    });
+  }
+
+  render() {
+    return (
+      <div className={style.form}>
+        <Form
+          layout="horizontal"
+          className={style.form}
+          style={{ paddingBottom: 25 }}
+        >
+          <FormItem
+            label="Label"
+            labelCol={{ span: 4 }}
+            wrapperCol={{ span: 20 }}
+          >
+            <Input
+              value={this.props.content.label}
+              data-id="label"
+              onChange={this.onFieldUpdate}
+            />
+          </FormItem>
+        </Form>
+        <DualRenderer
+          content={this.props.content}
+          rendering={this.state.rendering}
+          getImageInfo={(posx, posy) => null}
+        />
+      </div>
+    );
+  }
+}
+
+CoreEditor.propTypes = {
+  content: PropTypes.object.isRequired,
+  // core: PropTypes.object.isRequired,
+  coremaps: PropTypes.array.isRequired,
+  update: PropTypes.func.isRequired,
+  params: PropTypes.object.isRequired,
+  // imageSize: PropTypes.number,
+};
+
+CoreEditor.defaultProps = {
+  // imageSize: 512,
+};

--- a/src/widgets/DualRenderer.js
+++ b/src/widgets/DualRenderer.js
@@ -9,6 +9,7 @@ import { Switch } from 'antd';
 import VTKRenderer from './VTKRenderer';
 // import ImageGenerator from '../utils/ImageGenerator';
 import ImageRenderer from './ImageRenderer';
+import Color from './Color';
 
 import style from '../assets/vera.mcss';
 
@@ -28,11 +29,36 @@ export default class DualRenderer extends React.Component {
   render() {
     const contents = [];
     if (
+      this.props.content &&
+      this.props.content.legend &&
+      !(this.state.use3D && this.props.content.has3D)
+    ) {
+      contents.push(
+        <div key="2d-legend" className={style.legendContainer}>
+          {this.props.content.legend.map((m) => (
+            <Color
+              className={style.legend}
+              key={`core-${m.title}`}
+              title={m.title}
+              color={m.color}
+              border
+            />
+          ))}
+        </div>
+      );
+    }
+
+    if (
       this.props.content.imageSrc &&
       !(this.state.use3D && this.props.content.has3D)
     ) {
       contents.push(
-        <div key="2d-content" className={style.mainImage}>
+        <div
+          key="2d-content"
+          className={
+            this.props.content.legend ? style.mainImageFull : style.mainImage
+          }
+        >
           <ReactCursorPosition>
             <ImageRenderer
               content={this.props.content.imageSrc}


### PR DESCRIPTION
Show 3D view of core maps - without baffle/vessel/pads so far.
Switch between full core and elevation slices with a slider.
Slices can be viewed in 2D or 3D.