### PR TITLE
fix(simput): let simput use getTextMap for conversion

### DIFF
--- a/src/simput/index.js
+++ b/src/simput/index.js
@@ -4,6 +4,7 @@ import RodEditor from './RodEditor';
 import MapEditor from './MapEditor';
 import AssemblyEditor from './AssemblyEditor';
 import CoreEditor from './CoreEditor';
+import InpHelper from '../utils/InpHelper';
 
 function registerLocalEditors(Simput) {
   if (Simput && Simput.updateWidgetMapping) {
@@ -60,5 +61,10 @@ function registerLocalEditors(Simput) {
   }
 }
 
-const Simput = (typeof window === 'undefined' ? {} : window).Simput;
-registerLocalEditors(Simput);
+if (typeof window !== 'undefined') {
+  // expose global so simput/types/vera/src/convert.js can use it.
+  if (window.Simput.types.vera) {
+    window.Simput.types.vera.helper = { InpHelper };
+  }
+  registerLocalEditors(window.Simput);
+}

--- a/src/utils/GridMap.js
+++ b/src/utils/GridMap.js
@@ -225,4 +225,4 @@ export const newInstance = macro.newInstance(extend, 'vtkGridMap');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, SymmetryModes };

--- a/src/utils/ImageGenerator.js
+++ b/src/utils/ImageGenerator.js
@@ -239,6 +239,7 @@ function updateLayoutImage(
     ctx.stroke();
     // show an indication of symmetry
     if (item.symmetry) {
+      ctx.lineWidth = 3;
       const center = size * 0.5;
       if (item.symmetry === 'oct') {
         ctx.beginPath();
@@ -253,6 +254,7 @@ function updateLayoutImage(
         ctx.lineTo(0, center);
         ctx.stroke();
       }
+      ctx.lineWidth = 1;
     }
   }
 

--- a/src/utils/InpHelper.js
+++ b/src/utils/InpHelper.js
@@ -1,12 +1,31 @@
+import GridMap from './GridMap';
+
+const { SymmetryModes } = GridMap;
+// simput uses an enum for symmetry. Translate.
+const SymmetryMap = {
+  [SymmetryModes.NONE]: 'none',
+  [SymmetryModes.QUADRANT_MIRROR]: 'quad_mir',
+  [SymmetryModes.QUADRANT_ROTATION]: 'quad_rot',
+  [SymmetryModes.OCTANT]: 'oct',
+};
+
 function getNumPins(rodmap, params) {
   return rodmap.type === 'coremaps' ? params.numAssemblies : params.numPins;
+}
+
+function getSymmetry(sym) {
+  let symmetry = sym || 'none';
+  if (typeof symmetry === 'number') {
+    symmetry = SymmetryMap[symmetry];
+  }
+  return symmetry;
 }
 
 // given the full array, generate a text map reduced by symmetry.
 function getTextMap(rodmap, params) {
   const map = [];
   const { cell_map: cellMap } = rodmap;
-  const symmetry = rodmap.symmetry || 'none';
+  const symmetry = getSymmetry(rodmap.symmetry);
   const numPins = getNumPins(rodmap, params);
   const halfPins = Math.floor(numPins * 0.5);
   // copy from the lower-right quad, and left octant.
@@ -32,13 +51,14 @@ function getTextMap(rodmap, params) {
       map.push(cellMap.slice(i * numPins, (i + 1) * numPins).join(' '));
     }
   }
-  return map.join('\n');
+  const pad = params.pad || '';
+  return map.join(`\n${pad}`);
 }
 
 // given the text map with symmetry, generate the full array. Expand as necessary.
 function getFullMap(rodmap, params) {
   // Verify items in the cellMap. Unrecognized cells are empty.
-  const symmetry = rodmap.symmetry || 'none';
+  const symmetry = getSymmetry(rodmap.symmetry);
   const numPins = getNumPins(rodmap, params);
   let cellMap = [];
   if (rodmap.cellMap) cellMap = rodmap.cellMap.split(/[\n]+/);


### PR DESCRIPTION
Use a global and fix up InpHelper.getTextMap() so
simput can use it.

Make symmetry line display a bit thicker.